### PR TITLE
Update workflow versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,8 +124,8 @@ jobs:
           name: Test results (all modes)
           path: ${{ steps.testRunner.outputs.artifactsPath }}
 
-  buildForWebGL:
-    name: Build for StandaloneWindows64 🗗
+  buildForSomePlatforms:
+    name: Build for ${{ matrix.targetPlatform }} on version ${{ matrix.unityVersion }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -140,7 +140,6 @@ jobs:
           - StandaloneLinux64 # Build a Linux 64-bit standalone.
           - iOS # Build an iOS player.
           - WebGL # WebGL.
-
     steps:
       - uses: actions/checkout@v1
       - uses: actions/cache@v1.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,46 @@ env:
   UNITY_LICENSE: "<?xml version=\"1.0\" encoding=\"UTF-8\"?><root>\n    <License id=\"Terms\">\n        <MachineBindings>\n            <Binding Key=\"1\" Value=\"d39b8e2f4d364b2e98b06afa0c6e08c5\"/>\n            <Binding Key=\"2\" Value=\"d39b8e2f4d364b2e98b06afa0c6e08c5\"/>\n        </MachineBindings>\n        <MachineID Value=\"Xxo1ZKbdPu/IATrc0mPBYANJFF0=\"/>\n        <SerialHash Value=\"1efd68fa935192b6090ac03c77d289a9f588c55a\"/>\n        <Features>\n            <Feature Value=\"33\"/>\n            <Feature Value=\"1\"/>\n            <Feature Value=\"12\"/>\n            <Feature Value=\"2\"/>\n            <Feature Value=\"24\"/>\n            <Feature Value=\"3\"/>\n            <Feature Value=\"36\"/>\n            <Feature Value=\"17\"/>\n            <Feature Value=\"19\"/>\n            <Feature Value=\"62\"/>\n        </Features>\n        <DeveloperData Value=\"AQAAAEY0LUg2WFMtUE00NS1SM0M4LUUyWlotWkdWOA==\"/>\n        <SerialMasked Value=\"F4-H6XS-PM45-R3C8-E2ZZ-XXXX\"/>\n        <StartDate Value=\"2018-05-02T00:00:00\"/>\n        <UpdateDate Value=\"2019-11-25T18:23:38\"/>\n        <InitialActivationDate Value=\"2018-05-02T14:21:28\"/>\n        <LicenseVersion Value=\"6.x\"/>\n        <ClientProvidedVersion Value=\"2019.2.11f1\"/>\n        <AlwaysOnline Value=\"false\"/>\n        <Entitlements>\n            <Entitlement Ns=\"unity_editor\" Tag=\"UnityPersonal\" Type=\"EDITOR\" ValidTo=\"9999-12-31T00:00:00\"/>\n        </Entitlements>\n    </License>\n<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments\"/><SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\"/><Reference URI=\"#Terms\"><Transforms><Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/></Transforms><DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\"/><DigestValue>JHdOBFmBNq2H8BrGFzir/StLoYo=</DigestValue></Reference></SignedInfo><SignatureValue>aENLHd37a51RtP2/g7YU0Pexf5mx0/ENXYGtrPzqwZ8NQt2AsSdxGnl0CUB45/GuNXfJVDt2HWot\ncNYZB2OylVBn1WHQbKZlPmm8gEAMz0MYbr4Isb5i5buryBrZlmbEOjnRI+pEg1CBwlgMo6xdtjjE\n/d7cC293QIUO91kdzRXftYou1dNaUyuPL9ZH65vdB2pDXGRNxgUVD+GnnqZA7b5L2HXqNQclcWAK\n5Yd1BeF3VzR1iLw9G/SmH5oOhnpXSmqbL4qk7LVP2/mgXpFk5kP4X8VC3z47obNhBIGq40dwWyEe\nUYk5/nRAOkZawDT+tcu96e06gPC9Cxk5PdbRbA==</SignatureValue></Signature></root>"
 
 jobs:
+  readmeWorkflow:
+    # Checkout
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        lfs: true
+
+    # Cache
+    - uses: actions/cache@v1.1.0
+      with:
+        path: test-project/Library
+        key: Library-test-project-WebGL
+
+    # Test
+    - name: Run tests
+      uses: webbertakken/unity-test-runner@v1.2
+      with:
+        projectPath: test-project
+        unityVersion: 2019.2.11f1
+
+    # Build
+    - name: Build project
+      uses: webbertakken/unity-builder@v0.9
+      with:
+        projectPath: test-project
+        unityVersion: 2019.2.11f1
+        targetPlatform: WebGL
+
+    # Output
+    - uses: actions/upload-artifact@v1
+      with:
+        name: Build
+        path: build
+
+  #
+  # End of readme workflow.
+  #
+  # Below is a test of most combinations, for testing integrity.
+  #
+
   requestManualActivationFile:
     name: Request manual activation file 🔑
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,14 @@ jobs:
   requestManualActivationFile:
     name: Request manual activation file 🔑
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        unityVersion:
+          - 2018.4.15f1
+          - 2019.2.11f1
+          - 2019.2.14f1
+          - 2019.2.17f1
     steps:
       # Checkout repository
       - name: Checkout repository
@@ -18,8 +26,10 @@ jobs:
 
       # Request manual activation file
       - name: Request manual activation file
-        uses: webbertakken/unity-request-manual-activation-file@v1
         id: getManualLicenseFile
+        uses: webbertakken/unity-request-manual-activation-file@v1.1
+        with:
+          unityVersion: ${{ matrix.unityVersion }}
 
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
       - name: Expose as artifact

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,7 +231,7 @@ jobs:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
-          customParameters: "-myParameter myValue -myBoolean -ThirdParameter andItsValue
+          customParameters: "-myParameter myValue -myBoolean -ThirdParameter andItsValue"
       - uses: actions/upload-artifact@v1
         with:
           name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,13 +127,34 @@ jobs:
   buildForWebGL:
     name: Build for StandaloneWindows64 🗗
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        projectPath:
+          - test-project
+        unityVersion:
+          - 2019.2.11f1
+        targetPlatform:
+          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
+          - StandaloneWindows64 # Build a Windows 64-bit standalone.
+          - StandaloneLinux64 # Build a Linux 64-bit standalone.
+          - iOS # Build an iOS player.
+          - WebGL # WebGL.
+
     steps:
       - uses: actions/checkout@v1
-      - uses: webbertakken/unity-builder@v0.8
+      - uses: actions/cache@v1.1.0
         with:
-          projectPath: test-project
-          unityVersion: 2019.2.11f1
-          targetPlatform: StandaloneWindows64
+          path: ${{ matrix.projectPath }}/Library
+          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-
+            Library-
+      - uses: webbertakken/unity-builder@v0.9
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          targetPlatform: ${{ matrix.targetPlatform }}
       - uses: actions/upload-artifact@v1
         with:
           name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,22 @@ jobs:
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
+  activateAndThenReturnLicense:
+    name: returnLicense 🎈
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout repository (required to test local actions)
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Activate Unity
+      - name: Activate Unity
+        uses: webbertakken/unity-activate@v1.2
+
+      # Return License
+      - name: Return license
+        uses: webbertakken/unity-return-license@v0.1
+
   testRunnerInEditMode:
     name: Test in editmode 📝
     runs-on: ubuntu-latest
@@ -61,6 +77,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: true
+
+      # Cache
+      - uses: actions/cache@v1.1.0
+        with:
+          path: test-project/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
 
       # Configure test runner
       - name: Run tests
@@ -88,6 +113,15 @@ jobs:
         with:
           lfs: true
 
+      # Cache
+      - uses: actions/cache@v1.1.0
+        with:
+          path: test-project/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
+
       # Configure test runner
       - name: Run tests
         id: testRunner
@@ -113,6 +147,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: true
+
+      # Cache
+      - uses: actions/cache@v1.1.0
+        with:
+          path: test-project/Library
+          key: Library-test-project-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-test-project-
+            Library-
 
       # Configure test runner
       - name: Run tests
@@ -166,19 +209,3 @@ jobs:
         with:
           name: Build
           path: build
-
-  activateAndThenReturnLicense:
-    name: returnLicense 🎈
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout repository (required to test local actions)
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      # Activate Unity
-      - name: Activate Unity
-        uses: webbertakken/unity-activate@v1.2
-
-      # Return License
-      - name: Return license
-        uses: webbertakken/unity-return-license@v0.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,10 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         unityVersion:
-          - 2018.4.15f1
           - 2019.2.11f1
-          - 2019.2.14f1
-          - 2019.2.17f1
     steps:
       # Checkout repository
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       # Checkout repository
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       # Request manual activation file
       - name: Request manual activation file
@@ -44,7 +44,7 @@ jobs:
     steps:
       # Checkout repository
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       # Activate Unity
       - name: Unity - Activate
@@ -58,7 +58,9 @@ jobs:
     steps:
       # Checkout repository (required to test local actions)
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          lfs: true
 
       # Configure test runner
       - name: Run tests
@@ -82,7 +84,9 @@ jobs:
     steps:
       # Checkout repository (required to test local actions)
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          lfs: true
 
       # Configure test runner
       - name: Run tests
@@ -106,7 +110,9 @@ jobs:
     steps:
       # Checkout repository (required to test local actions)
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          lfs: true
 
       # Configure test runner
       - name: Run tests
@@ -141,7 +147,9 @@ jobs:
           - iOS # Build an iOS player.
           - WebGL # WebGL.
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
       - uses: actions/cache@v1.1.0
         with:
           path: ${{ matrix.projectPath }}/Library
@@ -168,7 +176,9 @@ jobs:
     steps:
       # Checkout repository (required to test local actions)
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+        with:
+          lfs: true
 
       # Activate Unity
       - name: Activate Unity

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,38 +9,41 @@ env:
 
 jobs:
   readmeWorkflow:
-    # Checkout
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        lfs: true
+    name: Readme Workflow ✨
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
 
-    # Cache
-    - uses: actions/cache@v1.1.0
-      with:
-        path: test-project/Library
-        key: Library-test-project-WebGL
+      # Cache
+      - uses: actions/cache@v1.1.0
+        with:
+          path: test-project/Library
+          key: Library-test-project-WebGL
 
-    # Test
-    - name: Run tests
-      uses: webbertakken/unity-test-runner@v1.2
-      with:
-        projectPath: test-project
-        unityVersion: 2019.2.11f1
+      # Test
+      - name: Run tests
+        uses: webbertakken/unity-test-runner@v1.2
+        with:
+          projectPath: test-project
+          unityVersion: 2019.2.11f1
 
-    # Build
-    - name: Build project
-      uses: webbertakken/unity-builder@v0.9
-      with:
-        projectPath: test-project
-        unityVersion: 2019.2.11f1
-        targetPlatform: WebGL
+      # Build
+      - name: Build project
+        uses: webbertakken/unity-builder@v0.9
+        with:
+          projectPath: test-project
+          unityVersion: 2019.2.11f1
+          targetPlatform: WebGL
 
-    # Output
-    - uses: actions/upload-artifact@v1
-      with:
-        name: Build
-        path: build
+      # Output
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Build
+          path: build
 
   #
   # End of readme workflow.
@@ -61,19 +64,16 @@ jobs:
           - 2019.2.17f1
     steps:
       # Checkout repository
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
       # Request manual activation file
-      - name: Request manual activation file
+      - uses: webbertakken/unity-request-manual-activation-file@v1.1
         id: getManualLicenseFile
-        uses: webbertakken/unity-request-manual-activation-file@v1.1
         with:
           unityVersion: ${{ matrix.unityVersion }}
 
       # Upload artifact (Unity_v20XX.X.XXXX.alf)
-      - name: Expose as artifact
-        uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v1
         with:
           name: Manual Activation File
           path: ${{ steps.getManualLicenseFile.outputs.filePath }}
@@ -82,39 +82,23 @@ jobs:
     name: Request activation ✔
     runs-on: ubuntu-latest
     steps:
-      # Checkout repository
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      # Activate Unity
-      - name: Unity - Activate
-        uses: webbertakken/unity-activate@v1.2
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+      - uses: actions/checkout@v2
+      - uses: webbertakken/unity-activate@v1.2
 
   activateAndThenReturnLicense:
     name: returnLicense 🎈
     runs-on: ubuntu-latest
     steps:
-      # Checkout repository (required to test local actions)
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      # Activate Unity
-      - name: Activate Unity
-        uses: webbertakken/unity-activate@v1.2
-
-      # Return License
-      - name: Return license
-        uses: webbertakken/unity-return-license@v0.1
+      - uses: actions/checkout@v2
+      - uses: webbertakken/unity-activate@v1.2
+      - uses: webbertakken/unity-return-license@v1
 
   testRunnerInEditMode:
     name: Test in editmode 📝
     runs-on: ubuntu-latest
     steps:
       # Checkout repository (required to test local actions)
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           lfs: true
 
@@ -128,17 +112,14 @@ jobs:
             Library-
 
       # Configure test runner
-      - name: Run tests
+      - uses: webbertakken/unity-test-runner@v1.2
         id: testRunner
-        uses: webbertakken/unity-test-runner@v1
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_PROJECT_PATH: test-project
-          TEST_MODE: editmode
+        with:
+          projectPath: test-project
+          testMode: editmode
 
       # Upload artifact
-      - name: Expose as artifact
-        uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v1
         with:
           name: Test results (edit mode)
           path: ${{ steps.testRunner.outputs.artifactsPath }}
@@ -148,8 +129,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout repository (required to test local actions)
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           lfs: true
 
@@ -163,17 +143,14 @@ jobs:
             Library-
 
       # Configure test runner
-      - name: Run tests
+      - uses: webbertakken/unity-test-runner@v1.2
         id: testRunner
-        uses: webbertakken/unity-test-runner@v1
         env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_PROJECT_PATH: test-project
-          TEST_MODE: playmode
+          projectPath: test-project
+          testMode: playmode
 
       # Upload artifact
-      - name: Expose as artifact
-        uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v1
         with:
           name: Test results (play mode)
           path: ${{ steps.testRunner.outputs.artifactsPath }}
@@ -183,8 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout repository (required to test local actions)
-      - name: Checkout repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           lfs: true
 
@@ -198,22 +174,23 @@ jobs:
             Library-
 
       # Configure test runner
-      - name: Run tests
+      - uses: webbertakken/unity-test-runner@v1.2
         id: testRunner
-        uses: webbertakken/unity-test-runner@v1
-        env:
-          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-          UNITY_PROJECT_PATH: test-project
-          TEST_MODE: all
+        with:
+          projectPath: test-project
+          testMode: all
 
       # Upload artifacts
-      - name: Expose as artifact
-        uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v1
         with:
           name: Test results (all modes)
           path: ${{ steps.testRunner.outputs.artifactsPath }}
 
-  buildForSomePlatforms:
+  #
+  # Complete advanced workflow
+  #
+
+  buildAndTestForSomePlatforms:
     name: Build for ${{ matrix.targetPlatform }} on version ${{ matrix.unityVersion }}
     runs-on: ubuntu-latest
     strategy:
@@ -240,11 +217,21 @@ jobs:
           restore-keys: |
             Library-${{ matrix.projectPath }}-
             Library-
+      - uses: webbertakken/unity-test-runner@v1.2
+        id: testRunner
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Test results (all modes)
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
       - uses: webbertakken/unity-builder@v0.9
         with:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
+          customParameters: "-myParameter myValue -myBoolean -ThirdParameter andItsValue
       - uses: actions/upload-artifact@v1
         with:
           name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,14 +26,14 @@ jobs:
 
       # Test
       - name: Run tests
-        uses: webbertakken/unity-test-runner@v1.2
+        uses: webbertakken/unity-test-runner@v1.3
         with:
           projectPath: test-project
           unityVersion: 2019.2.11f1
 
       # Build
       - name: Build project
-        uses: webbertakken/unity-builder@v0.9
+        uses: webbertakken/unity-builder@v0.10
         with:
           projectPath: test-project
           unityVersion: 2019.2.11f1
@@ -112,7 +112,7 @@ jobs:
             Library-
 
       # Configure test runner
-      - uses: webbertakken/unity-test-runner@v1.2
+      - uses: webbertakken/unity-test-runner@v1.3
         id: testRunner
         with:
           projectPath: test-project
@@ -143,9 +143,9 @@ jobs:
             Library-
 
       # Configure test runner
-      - uses: webbertakken/unity-test-runner@v1.2
+      - uses: webbertakken/unity-test-runner@v1.3
         id: testRunner
-        env:
+        with:
           projectPath: test-project
           testMode: playmode
 
@@ -174,7 +174,7 @@ jobs:
             Library-
 
       # Configure test runner
-      - uses: webbertakken/unity-test-runner@v1.2
+      - uses: webbertakken/unity-test-runner@v1.3
         id: testRunner
         with:
           projectPath: test-project
@@ -217,7 +217,7 @@ jobs:
           restore-keys: |
             Library-${{ matrix.projectPath }}-
             Library-
-      - uses: webbertakken/unity-test-runner@v1.2
+      - uses: webbertakken/unity-test-runner@v1.3
         id: testRunner
         with:
           projectPath: ${{ matrix.projectPath }}
@@ -226,7 +226,7 @@ jobs:
         with:
           name: Test results (all modes)
           path: ${{ steps.testRunner.outputs.artifactsPath }}
-      - uses: webbertakken/unity-builder@v0.9
+      - uses: webbertakken/unity-builder@v0.10
         with:
           projectPath: ${{ matrix.projectPath }}
           unityVersion: ${{ matrix.unityVersion }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Activate Unity
       - name: Unity - Activate
-        uses: webbertakken/unity-activate@v1
+        uses: webbertakken/unity-activate@v1.2
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
@@ -170,19 +170,14 @@ jobs:
   activateAndThenReturnLicense:
     name: returnLicense 🎈
     runs-on: ubuntu-latest
-    env:
-      UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
-
     steps:
       # Checkout repository (required to test local actions)
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          lfs: true
 
       # Activate Unity
       - name: Activate Unity
-        uses: webbertakken/unity-activate@v1
+        uses: webbertakken/unity-activate@v1.2
 
       # Return License
       - name: Return license

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ either `personal` or `professoinal` license below.
    [Request Manual Activation File](https://github.com/marketplace/actions/unity-request-activation-file).
 3. Request your license on 
    [license.unity3d.com](https://license.unity3d.com/manual).
-4. Open `Github` > `<Your repository>` > `Settings` > `Secrets` and set the contents of the resulting license file to `UNITY_LICENSE` as a secret.
+4. Open `Github` > `<Your repository>` > `Settings` > `Secrets`
+5. Create a secret called `UNITY_LICENSE` and add the contents of the obtained license file.
 
 ##### Professional license
 
-1. Open `Github` > `<Your repository>` > `Settings` > `Secrets` and create the following secrets;
+1. Open `Github` > `<Your repository>` > `Settings` > `Secrets`
+2. Create the following secrets;
     - `UNITY_SERIAL` - _(Add the code that looks like `XX-XXXX-XXXX-XXXX-XXXX-XXXX`)_
     - `UNITY_EMAIL` - _(Add the email address that you use to login to Unity)_
     - `UNITY_PASSWORD` - _(Add the password that you use to login to Unity)_
@@ -66,7 +68,7 @@ either `personal` or `professoinal` license below.
   and for pro licenses also 
     [Return License](https://github.com/marketplace/actions/unity-return-license). This is to free up the license allocation after usage.
 
-    > Note: Test runner and Builder already include these steps.
+    > _Note: Test runner and Builder already include these steps._
 
 ### Setting up a workflow
 
@@ -86,12 +88,14 @@ Create a file called `.github/workflows/main.yml` in your repository and configu
 
 Detailed instructions for each step can be found in the corresponding actions.
 
-#### Example
+## Simple example
 
 Below is a simple example.
  
 This example assumes that your Unity project is in the root of your repository.
 
+> _Note: this repository tests this workflow_
+>
 ```yaml
 name: Actions 😎
 
@@ -140,6 +144,71 @@ jobs:
           path: build
 ```
 
+## Advanced example
+
+To get an idea of how to create a more advanced workflows,
+have a look at the example below.
+
+> _Note: this repository tests this workflow_
+
+```yaml
+name: Actions 😎
+
+on:
+  pull_request: {}
+  push: { branches: [master] }
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+
+jobs:
+  buildAndTestForSomePlatforms:
+    name: Build for ${{ matrix.targetPlatform }} on version ${{ matrix.unityVersion }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        projectPath:
+          - test-project
+        unityVersion:
+          - 2019.2.11f1
+        targetPlatform:
+          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
+          - StandaloneWindows64 # Build a Windows 64-bit standalone.
+          - StandaloneLinux64 # Build a Linux 64-bit standalone.
+          - iOS # Build an iOS player.
+          - WebGL # WebGL.
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+      - uses: actions/cache@v1.1.0
+        with:
+          path: ${{ matrix.projectPath }}/Library
+          key: Library-${{ matrix.projectPath }}-${{ matrix.targetPlatform }}
+          restore-keys: |
+            Library-${{ matrix.projectPath }}-
+            Library-
+      - uses: webbertakken/unity-test-runner@v1.3
+        id: testRunner
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Test results (all modes)
+          path: ${{ steps.testRunner.outputs.artifactsPath }}
+      - uses: webbertakken/unity-builder@v0.10
+        with:
+          projectPath: ${{ matrix.projectPath }}
+          unityVersion: ${{ matrix.unityVersion }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+          customParameters: "-myParameter myValue -myBoolean -ThirdParameter andItsValue"
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Build
+          path: build
+```
 ## Project Status
 
 #### Checkout

--- a/README.md
+++ b/README.md
@@ -1,33 +1,142 @@
 # Unity Actions
 
-[![Actions status](https://github.com/webbertakken/unity-actions/workflows/Actions%20😎/badge.svg)](https://github.com/webbertakken/unity-actions/actions?query=branch%3Amaster+workflow%3A%22Actions+%F0%9F%98%8E%22)
+[![Actions status](https://github.com/webbertakken/unity-actions/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-actions/actions?query=branch%3Amaster+event%3Apush+workflow%3A"Actions%20%F0%9F%98%8E")
 
 ---
 
-GitHub Actions for testing and building Unity projects.
-
-Contributions are welcomed!
+The fastest and **easiest** way to automatically test and build any Unity project!
 
 ---
 
-## Workflow steps
+#### Supported versions
 
-Here's a complete mental model of how to build, test and deploy your Unity app.
+It's generally considered good practice to use the same unity version for Unity Actions as you do to develop your project.
+
+Check the [list](https://hub.docker.com/r/gableroux/unity3d/tags) of supported versions by Unity Actions. 
+
+## Setup
+
+##### Mental model
+
+There are two parts to setting up Unity Actions;
+
+- Configuring a license
+- Setting up a workflow
+
+Both steps are described in detail below;
+
+##### First time using GitHub Actions?
+
+Read the official documentation on how to setup a 
+[workflow](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow).
+
+Any subsequent steps assume you have read the above.
+
+#### Setting up license
+
+All actions utilize an installment of Unity, and as such need to be activated.
+
+To set up your license for use in Unity Actions, create a file called 
+`.github/workflows/activate.yml` in your repository and follow the steps for 
+either `personal` or `professoinal` license below.
+
+##### Personal license
  
-1. Checkout your repository
-2. Configure `request activation file` job.
-3. Activate your license and 
-[add](https://github.com/webbertakken/unity-request-manual-activation-file)
-the environment variable `UNITY_LICENSE`.
-    - Optionally verify your license using `Activate licence` job.
-4. Configure your test jobs.
-5. Create builds for your desired targets.
-6. Optionally, return your license (applicable to pro licenses only)
-7. Deploy your application.
+1. Request your activation file for usage on GitHub using
+   [Request Manual Activation File](https://github.com/marketplace/actions/unity-request-activation-file).
+3. Request your license on 
+   [license.unity3d.com](https://license.unity3d.com/manual).
+4. Open `Github` > `<Your repository>` > `Settings` > `Secrets` and set the contents of the resulting license file to `UNITY_LICENSE` as a secret.
 
-Detailed instructions can be found in each action below.
+##### Professional license
 
-## Jobs
+1. Open `Github` > `<Your repository>` > `Settings` > `Secrets` and create the following secrets;
+    - `UNITY_SERIAL` - _(Add the code that looks like `XX-XXXX-XXXX-XXXX-XXXX-XXXX`)_
+    - `UNITY_EMAIL` - _(Add the email address that you use to login to Unity)_
+    - `UNITY_PASSWORD` - _(Add the password that you use to login to Unity)_
+
+##### Optional steps
+
+- Verify your license using 
+  [Activate](https://github.com/marketplace/actions/unity-activate)
+  and for pro licenses also 
+    [Return License](https://github.com/marketplace/actions/unity-return-license). This is to free up the license allocation after usage.
+
+    > Note: Test runner and Builder already include these steps.
+
+#### Setting up a workflow
+
+Setting up a workflow is easy!
+
+Create a file called `.github/workflows/main.yml` in your repository and configure the following steps;
+
+1. Checkout a repository using
+ [Checkout](https://github.com/marketplace/actions/checkout).
+2. Cache your library folder using 
+[Cache](https://github.com/marketplace/actions/cache).
+3. Configure your test job using 
+ [Test Runner](https://github.com/marketplace/actions/unity-test-runner).
+4. Configure your build job using 
+ [Builder](https://github.com/marketplace/actions/unity-builder). 
+5. Deploy your application.
+
+Detailed instructions for each step can be found in the corresponding actions.
+
+#### Example
+
+Below is a simple example.
+ 
+This example assumes that your Unity project is in the root of your repository.
+
+```yaml
+name: Actions 😎
+
+on:
+  pull_request: {}
+  push: { branches: [master] }
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+
+jobs:
+  build:
+    name: Build my project ✨
+    runs-on: ubuntu-latest
+    steps:
+    
+      # Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+    
+      # Cache
+      - uses: actions/cache@v1.1.0
+        with:
+          path: Library
+          key: Library
+
+      # Test
+      - name: Run tests
+        uses: webbertakken/unity-test-runner@v1.2
+        with:
+          unityVersion: 2019.2.11f1
+
+      # Build
+      - name: Build project
+        uses: webbertakken/unity-builder@v0.9
+        with:
+          unityVersion: 2019.2.11f1
+          targetPlatform: WebGL 
+
+      # Output 
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Build
+          path: build
+```
+
+## Project Status
 
 #### Checkout
 
@@ -39,28 +148,28 @@ Detailed instructions can be found in each action below.
 
 | Description             | Done | Status |
 |-------------------------|------|--------|
-| [Request activation file](https://github.com/marketplace/actions/unity-request-activation-file) | ✔ | [![Actions status](https://github.com/webbertakken/unity-request-manual-activation-file/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-request-manual-activation-file) |
-| [Activate license](https://github.com/marketplace/actions/unity-activate) | ✔ | [![Actions status](https://github.com/webbertakken/unity-activate/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-activate) |
-| [Return license](https://github.com/marketplace/actions/unity-return-license) | ✔ | [![Actions status](https://github.com/webbertakken/unity-return-license/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-return-license) |
+| [Request activation file](https://github.com/marketplace/actions/unity-request-activation-file) | ✔ | [![Actions status](https://github.com/webbertakken/unity-request-manual-activation-file/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-request-manual-activation-file) |
+| [Activate license](https://github.com/marketplace/actions/unity-activate) | ✔ | [![Actions status](https://github.com/webbertakken/unity-activate/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-activate) |
+| [Return license](https://github.com/marketplace/actions/unity-return-license) | ✔ | [![Actions status](https://github.com/webbertakken/unity-return-license/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-return-license) |
 
 #### Test
 
 | Description             | Done | Status |
 |-------------------------|------|--------|
-| [Test edit mode](https://github.com/marketplace/actions/unity-test-runner) | ✔ | [![Actions status](https://github.com/webbertakken/unity-test-runner/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-test-runner#edit-mode) |
-| [Test play mode](https://github.com/marketplace/actions/unity-test-runner) | ✔ | [![Actions status](https://github.com/webbertakken/unity-test-runner/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-test-runner#play-mode) |
-| [Test all in one](https://github.com/marketplace/actions/unity-test-runner) | ✔ | [![Actions status](https://github.com/webbertakken/unity-test-runner/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-test-runner#all-in-one-mode) |
+| [Test edit mode](https://github.com/marketplace/actions/unity-test-runner) | ✔ | [![Actions status](https://github.com/webbertakken/unity-test-runner/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-test-runner#edit-mode) |
+| [Test play mode](https://github.com/marketplace/actions/unity-test-runner) | ✔ | [![Actions status](https://github.com/webbertakken/unity-test-runner/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-test-runner#play-mode) |
+| [Test all in one](https://github.com/marketplace/actions/unity-test-runner) | ✔ | [![Actions status](https://github.com/webbertakken/unity-test-runner/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-test-runner#all-in-one-mode) |
 
 #### Build
 
 | Description             | Done | Status |
 |-------------------------|------|--------|
-| [Build for WebGL](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-builder#webgl) |
-| [Build for Windows](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-builder#windows) |
-| [Build for Linux](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-builder#linux) |
-| [Build for MacOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-builder#macos) |
+| [Build for WebGL](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-builder#webgl) |
+| [Build for Windows](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-builder#windows) |
+| [Build for Linux](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-builder#linux) |
+| [Build for MacOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-builder#macos) |
 | [Build for Android](https://github.com/marketplace/actions/unity-builder) | ❌ | In progress |
-| [Build for iOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg)](https://github.com/webbertakken/unity-builder#ios) |
+| [Build for iOS](https://github.com/marketplace/actions/unity-builder) | ✔ | [![Actions status](https://github.com/webbertakken/unity-builder/workflows/Actions%20%F0%9F%98%8E/badge.svg?event=push&branch=master)](https://github.com/webbertakken/unity-builder#ios) |
 | [Build for Windows store](https://github.com/marketplace/actions/unity-builder) | ❌ | In progress |
 | [Build for PS4](https://github.com/marketplace/actions/unity-builder) | ❌ | In progress |
 | [Build for XboxOne](https://github.com/marketplace/actions/unity-builder) | ❌ | In progress |

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ The fastest and **easiest** way to automatically test and build any Unity projec
 
 ---
 
-#### Supported versions
+##### Supported versions
 
-It's generally considered good practice to use the same unity version for Unity Actions as you do to develop your project.
+It's generally considered good practice to use the same Unity version for Unity Actions as you do to develop your project.
 
-Check the [list](https://hub.docker.com/r/gableroux/unity3d/tags) of supported versions by Unity Actions. 
+Unity Actions are based on the 
+[unity3d](https://gitlab.com/gableroux/unity3d) 
+images from 
+[GabLeRoux](https://github.com/GabLeRoux). 
+Any version in this 
+[list](https://hub.docker.com/r/gableroux/unity3d/tags)
+can be used to test and build projects.
 
 ## Setup
 
@@ -23,8 +29,6 @@ There are two parts to setting up Unity Actions;
 - Configuring a license
 - Setting up a workflow
 
-Both steps are described in detail below;
-
 ##### First time using GitHub Actions?
 
 Read the official documentation on how to setup a 
@@ -32,7 +36,7 @@ Read the official documentation on how to setup a
 
 Any subsequent steps assume you have read the above.
 
-#### Setting up license
+### Setting up license
 
 All actions utilize an installment of Unity, and as such need to be activated.
 
@@ -64,7 +68,7 @@ either `personal` or `professoinal` license below.
 
     > Note: Test runner and Builder already include these steps.
 
-#### Setting up a workflow
+### Setting up a workflow
 
 Setting up a workflow is easy!
 
@@ -180,9 +184,6 @@ jobs:
 
 A full example implementation can be found in `main.yml` of this repo.
 
-## Credits
+## Licence 
 
-Huge thanks to
-[GabLeRoux](https://github.com/GabLeRoux)
-for his docker [image](https://hub.docker.com/r/gableroux/unity3d/)
-and gitlab-ci [example](https://gitlab.com/gableroux/unity3d).
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -122,13 +122,13 @@ jobs:
 
       # Test
       - name: Run tests
-        uses: webbertakken/unity-test-runner@v1.2
+        uses: webbertakken/unity-test-runner@v1.3
         with:
           unityVersion: 2019.2.11f1
 
       # Build
       - name: Build project
-        uses: webbertakken/unity-builder@v0.9
+        uses: webbertakken/unity-builder@v0.10
         with:
           unityVersion: 2019.2.11f1
           targetPlatform: WebGL 


### PR DESCRIPTION
- Upgrade workflow to use latest versions
- Add example to readme
- Make readme more beginner friendly
- Move credits to the top and combine with supported versions section
- Update badges to only show status of each upstream master
- closes https://github.com/webbertakken/unity-actions/issues/14 (make readme more beginner friendly)
- closes https://github.com/webbertakken/unity-builder/issues/30 (added insights for successful builds)
- closes https://github.com/webbertakken/unity-actions/issues/33 (all repos have been updated, got their own static license and went up by a minor version, all badges were checked and the central workflow in this repository was updated.)